### PR TITLE
Use postgresql as db

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,15 @@
+DEBUG=1
+SECRET_KEY=supersectretkey
+
+DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1]
+DJANGO_SUPERUSER_USERNAME=admin
+DJANGO_SUPERUSER_PASSWORD=admin
+DJANGO_SUPERUSER_EMAIL=admin@admin.com
+
+SQL_ENGINE=django.db.backends.postgresql
+SQL_DATABASE=hello_django_dev
+SQL_USER=hello_django
+SQL_PASSWORD=hello_django
+SQL_HOST=db
+SQL_PORT=5432
+DATABASE=postgres

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+.env.prod
+.env.prod.db
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -16,21 +16,21 @@ This will start the container but not the web app. The `app` folder is mounted t
 
 - (Optional) To start the web app run inside the container
 
-```
-docker compose exec web python3 manage.py runserver 0.0.0.0:8000
-```
+  ```
+  docker compose exec web python3 manage.py runserver 0.0.0.0:8000
+  ```
 
 - (Optional) To see if the dbs were created correctly run
 
-```
-docker-compose exec db psql --username=hello_django --dbname=hello_django_dev
-```
+  ```
+  docker compose exec db psql --username=hello_django --dbname=hello_django_dev
+  ```
 
 And type `\l` to list all databases.
 
 ### Production
 
-1. To use it in production mode use the `production.yml` file
+To use it in production mode use the `production.yml` file
 
 ```
 docker compose -f production.yml up -d --build

--- a/README.md
+++ b/README.md
@@ -14,19 +14,19 @@ A habit tracker for tracking water intake.
 
    This will start the container but not the web app. The `app` folder is mounted to the container so you can read and write from the host machine.
 
-- (Optional) To start the web app run inside the container
+2. (Optional) To start the web app run inside the container
 
-  ```
-  docker compose exec web python3 manage.py runserver 0.0.0.0:8000
-  ```
+   ```
+   docker compose exec web python3 manage.py runserver 0.0.0.0:8000
+   ```
 
-- (Optional) To see if the dbs were created correctly run
+3. (Optional) To see if the dbs were created correctly run
 
-  ```
-  docker compose exec db psql --username=hello_django --dbname=hello_django_dev
-  ```
+   ```
+   docker compose exec db psql --username=hello_django --dbname=hello_django_dev
+   ```
 
-And type `\l` to list all databases.
+   And type `\l` to list all databases.
 
 ### Production
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ A habit tracker for tracking water intake.
 
 1. To run the app clone this repo and run
 
-```
-docker compose up -d
-```
+   ```
+   docker compose up -d
+   ```
 
-This will start the container but not the web app. The `app` folder is mounted to the container so you can read and write from the host machine.
+   This will start the container but not the web app. The `app` folder is mounted to the container so you can read and write from the host machine.
 
 - (Optional) To start the web app run inside the container
 

--- a/README.md
+++ b/README.md
@@ -6,26 +6,36 @@ A habit tracker for tracking water intake.
 
 ### Development
 
-To run the app clone this repo and run
+1. To run the app clone this repo and run
 
 ```
 docker compose up -d
 ```
 
 This will start the container but not the web app. The `app` folder is mounted to the container so you can read and write from the host machine.
-To start the web app run inside the container
+
+- (Optional) To start the web app run inside the container
 
 ```
-python3 manage.py runserver 0.0.0.0:8000
+docker compose exec web python3 manage.py runserver 0.0.0.0:8000
 ```
+
+- (Optional) To see if the dbs were created correctly run
+
+```
+docker-compose exec db psql --username=hello_django --dbname=hello_django_dev
+```
+
+And type `\l` to list all databases.
 
 ### Production
 
-To use it in production mode use the `production.yml` file
+1. To use it in production mode use the `production.yml` file
 
 ```
-docker compose -f production.yml build
-docker compose -f production.yml up -d
+docker compose -f production.yml up -d --build
 ```
 
 The web app will be available at `localhost:8000`.
+
+> **Hint:** The `--build` flag is required because in production mode the app directory is not mounted to the container.

--- a/app/backend/settings.py
+++ b/app/backend/settings.py
@@ -28,13 +28,13 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = env('SECRET_KEY',
-                'h8+mu_iy6%5j%7+hp**+gsq$nmy!!mjd8z_qkd94@z!%9%!+qn')
+SECRET_KEY = os.environ.get("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = env.bool('DEBUG', True)
+DEBUG = bool(os.environ.get("DEBUG", default=0))
 
-ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", ("localhost", "127.0.0.1"))
+ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS").split(" ")
+
 
 
 # Application definition
@@ -84,9 +84,13 @@ WSGI_APPLICATION = 'backend.wsgi.application'
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    "default": {
+        "ENGINE": os.environ.get("SQL_ENGINE", "django.db.backends.sqlite3"),
+        "NAME": os.environ.get("SQL_DATABASE", BASE_DIR + "/db.sqlite3"),
+        "USER": os.environ.get("SQL_USER", "user"),
+        "PASSWORD": os.environ.get("SQL_PASSWORD", "password"),
+        "HOST": os.environ.get("SQL_HOST", "localhost"),
+        "PORT": os.environ.get("SQL_PORT", "5432"),
     }
 }
 

--- a/app/backend/urls.py
+++ b/app/backend/urls.py
@@ -19,5 +19,5 @@ from django.urls import include, path
 
 urlpatterns = [
     path('test/', include('drinklog.urls')),
-    path(r'^admin/', admin.site.urls),
+    url(r'admin/', admin.site.urls),
 ]

--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Wait for Postgres to start
+if [ "$DATABASE" = "postgres" ]
+then
+    echo "Waiting for postgres..."
+
+    while ! nc -z $SQL_HOST $SQL_PORT; do
+      sleep 0.1
+    done
+
+    echo "PostgreSQL started"
+fi
+
+# Then apply migrations
+python manage.py flush --no-input
+python manage.py migrate
+
+exec "$@"

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,2 +1,3 @@
 Django==3.2.13
 environs==7.3.1
+psycopg2-binary==2.9.9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,11 +19,11 @@ services:
     container_name: drinklog-db
     image: postgres:15
     volumes:
-      - postgres_data:/var/lib/postgresql/data/
+      - db-dev:/var/lib/postgresql/data/
     environment:
       - POSTGRES_USER=hello_django
       - POSTGRES_PASSWORD=hello_django
       - POSTGRES_DB=hello_django_dev
 
 volumes:
-  postgres_data:
+  db-dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,29 @@
+# Development environmet
+
 services:
   web:
     container_name: drinklog-dev
     build:
       context: .
       target: builder
-    entrypoint: ["sleep", "infinity"]
+    command: >
+      sh -c "/app/docker-entrypoint.sh && python3 manage.py flush --no-input && python3 manage.py migrate && python3 manage.py createsuperuser --noinput && sleep infinity"
     ports:
       - "8000:8000"
+    env_file:
+      - ./.env.dev
     volumes:
       - ./app:/app
+
+  db:
+    container_name: drinklog-db
+    image: postgres:15
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+    environment:
+      - POSTGRES_USER=hello_django
+      - POSTGRES_PASSWORD=hello_django
+      - POSTGRES_DB=hello_django_dev
+
+volumes:
+  postgres_data:

--- a/production.yml
+++ b/production.yml
@@ -17,9 +17,9 @@ services:
     container_name: drinklog-db
     image: postgres:15
     volumes:
-      - postgres_data:/var/lib/postgresql/data/
+      - db:/var/lib/postgresql/data/
     env_file:
       - ./.env.prod.db
 
 volumes:
-  postgres_data:
+  db:

--- a/production.yml
+++ b/production.yml
@@ -1,9 +1,25 @@
+# Production environment
+
 services:
   web:
-    container_name: drinklog
+    container_name: drinklog-web
     build:
       context: .
       target: production
-    entrypoint: ["python3", "manage.py", "runserver", "0.0.0.0:8000"]
+    command: >
+      sh -c "python3 manage.py runserver --noreload 0.0.0.0:8000"
     ports:
       - "8000:8000"
+    env_file:
+      - ./.env.prod
+
+  db:
+    container_name: drinklog-db
+    image: postgres:15
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+    env_file:
+      - ./.env.prod.db
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
Use postrgesql in a seperate container as a more scalable db than the default sqlite. Also made changes to the docker setup and splitting into dev and production.