### PR TITLE
Color a bar in black when `overdrive==True`

### DIFF
--- a/app/base/views.py
+++ b/app/base/views.py
@@ -109,22 +109,34 @@ class DeleteView(LoginRequiredMixin, DeleteView):
 
 def logplot(request):
     current_user = request.user
+    
     all_logs = Log.objects.all()
     users = [log.user for log in all_logs]
     dates = [log.date for log in all_logs]
     intensities = [log.intensity for log in all_logs]
+    overdrives = [log.overdrive for log in all_logs]
 
-    df = pd.DataFrame({"user": users, "date": dates, "intensity": intensities})
+    # Create df
+    df = pd.DataFrame({"user": users, "date": dates, "intensity": intensities, "overdrive": overdrives})
     df_current_user = df[df["user"] == current_user]
 
+    # Add color column with black values when overdrive==True
+    df_current_user['color'] = df_current_user.apply(lambda row: 0 if row['overdrive'] else row['intensity'], axis=1)
+
+    print(df_current_user['color'])
+
+    # Erstellen des Barplots
     fig_bar = px.bar(
         df_current_user,
         x="date",
         y="intensity",
         title="Drinklog Plot",
         labels={"intensity": "Intensity", "date": "Date"},
-        color="intensity",
-        color_continuous_scale=["#00B86B", "#D78F09", "#CD133B"],
+        color = df_current_user["color"],
+        color_continuous_scale=["black",
+            "#00B86B", "#36AE53", "#6CA43A", "#A29A22", 
+            "#D78F09", "#D57016", "#D25122", "#D0322F",
+            "#CD133B",],
     )
     fig_bar.update_layout(
         paper_bgcolor="rgba(0,0,0,0)",

--- a/app/base/views.py
+++ b/app/base/views.py
@@ -11,8 +11,7 @@ from django.shortcuts import redirect, render
 from django.urls import reverse_lazy
 from django.views import View
 from django.views.generic.detail import DetailView
-from django.views.generic.edit import (CreateView, DeleteView, FormView,
-                                       UpdateView)
+from django.views.generic.edit import (CreateView, DeleteView, FormView, UpdateView)
 from django.views.generic.list import ListView
 
 from .models import Log
@@ -125,12 +124,11 @@ def logplot(request):
 
     print(df_current_user['color'])
 
-    # Erstellen des Barplots
+    # Creation of the plot
     fig_bar = px.bar(
         df_current_user,
         x="date",
         y="intensity",
-        title="Drinklog Plot",
         labels={"intensity": "Intensity", "date": "Date"},
         color = df_current_user["color"],
         color_continuous_scale=["black",
@@ -144,6 +142,7 @@ def logplot(request):
         font_color="white",
         title_font_family="Jost",
         modebar_orientation="v",
+        coloraxis_showscale=False,
     )
     bar_chart = fig_bar.to_html(full_html=False, include_plotlyjs=False)
 

--- a/app/base/views.py
+++ b/app/base/views.py
@@ -11,7 +11,8 @@ from django.shortcuts import redirect, render
 from django.urls import reverse_lazy
 from django.views import View
 from django.views.generic.detail import DetailView
-from django.views.generic.edit import (CreateView, DeleteView, FormView, UpdateView)
+from django.views.generic.edit import (CreateView, DeleteView, FormView,
+                                       UpdateView)
 from django.views.generic.list import ListView
 
 from .models import Log
@@ -108,7 +109,7 @@ class DeleteView(LoginRequiredMixin, DeleteView):
 
 def logplot(request):
     current_user = request.user
-    
+
     all_logs = Log.objects.all()
     users = [log.user for log in all_logs]
     dates = [log.date for log in all_logs]
@@ -116,13 +117,22 @@ def logplot(request):
     overdrives = [log.overdrive for log in all_logs]
 
     # Create df
-    df = pd.DataFrame({"user": users, "date": dates, "intensity": intensities, "overdrive": overdrives})
+    df = pd.DataFrame(
+        {
+            "user": users,
+            "date": dates,
+            "intensity": intensities,
+            "overdrive": overdrives,
+        }
+    )
     df_current_user = df[df["user"] == current_user]
 
     # Add color column with black values when overdrive==True
-    df_current_user['color'] = df_current_user.apply(lambda row: 0 if row['overdrive'] else row['intensity'], axis=1)
+    df_current_user["color"] = df_current_user.apply(
+        lambda row: 0 if row["overdrive"] else row["intensity"], axis=1
+    )
 
-    print(df_current_user['color'])
+    print(df_current_user["color"])
 
     # Creation of the plot
     fig_bar = px.bar(
@@ -130,11 +140,19 @@ def logplot(request):
         x="date",
         y="intensity",
         labels={"intensity": "Intensity", "date": "Date"},
-        color = df_current_user["color"],
-        color_continuous_scale=["black",
-            "#00B86B", "#36AE53", "#6CA43A", "#A29A22", 
-            "#D78F09", "#D57016", "#D25122", "#D0322F",
-            "#CD133B",],
+        color=df_current_user["color"],
+        color_continuous_scale=[
+            "black",
+            "#00B86B",
+            "#36AE53",
+            "#6CA43A",
+            "#A29A22",
+            "#D78F09",
+            "#D57016",
+            "#D25122",
+            "#D0322F",
+            "#CD133B",
+        ],
     )
     fig_bar.update_layout(
         paper_bgcolor="rgba(0,0,0,0)",


### PR DESCRIPTION
## Closes #19 

### Changes made by this Pull Request

- Add black to the lower end of the color scale
- Add an extra column `color` to the DataFrame that copies `intensity`
- Set the `color` to `0` when `overdrive==True`
- Manually add more color values around green, yellow and red to increase their relative share of the continuous color spectrum. Otherwise low numbers would also look like black. With this change a 1 looks more LaCie a dark green.

This is not a perfect solution but imo it’s good enough. I couldn’t manage to find a way for doing this better. It seems like not many people have a problem like me.
