### PR TITLE
Log merging on same dates

### DIFF
--- a/app/base/views.py
+++ b/app/base/views.py
@@ -108,7 +108,9 @@ class LogUpdate(LoginRequiredMixin, UpdateView):
 
     def get_form(self, form_class=None):
         form = super().get_form(form_class)
-        form.fields["date"].widget = forms.DateInput(attrs={"type": "date"})
+        form.fields["date"].disabled = True
+        form.fields["date"].widget.attrs['readonly'] = True
+        form.fields["date"].widget = forms.DateInput(attrs={"type": "date", "readonly": "readonly"})
         form.fields["intensity"].widget = forms.TextInput(
             attrs={"type": "range", "min": "0", "max": "25", "value": "0"}
         )


### PR DESCRIPTION
## Closes #61

### Changes made by this Pull Request

- When creating a second log on the same date as an existing one they get merged. Meaning: `intensity` gets added up; `overdrive` is combined with a logical OR
- To prevent errors when updating a log the date field is disabled in LogUpdate-view